### PR TITLE
Update Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -97,7 +97,7 @@ copy: $(TARGET)
 all: copy
 
 $(TARGET): ${OBJS}
-	$(CC) $(CFLAGS) -lcrypto -o $(TARGET) ${OBJS} $(LDFLAGS) $(LIBS)
+	$(CC) $(CFLAGS) -o $(TARGET) ${OBJS} $(LDFLAGS) $(LIBS) -lcrypto
 
 .SUFFIXES:
 .SUFFIXES: .c .o


### PR DESCRIPTION
On ubuntu 14,  when install, error occurs as below:

> main.o: In function `validate':
> main.c:(.text+0x327): undefined reference to `d2i_PKCS7_bio'
> main.c:(.text+0x563): undefined reference to `EVP_MD_CTX_init'
> main.c:(.text+0x568): undefined reference to `EVP_sha1'
> main.c:(.text+0x57f): undefined reference to `EVP_DigestInit_ex'
> main.c:(.text+0x59c): undefined reference to `EVP_DigestUpdate'
> main.c:(.text+0x5c2): undefined reference to `EVP_DigestUpdate'
> main.c:(.text+0x5e8): undefined reference to `EVP_DigestUpdate'
> main.c:(.text+0x600): undefined reference to `EVP_DigestFinal_ex'

Put -lcrpyto at end of link command fix the issue.
you can reference this link:
https://stackoverflow.com/questions/22988320/undefined-reference-to-sha1-at-line