### PR TITLE
Hide password from logs

### DIFF
--- a/lib/apple.js
+++ b/lib/apple.js
@@ -172,7 +172,15 @@ function validatePurchase(receipt, options, cb) {
     content.password = options.secret;
   }
 
-  logDebug('<Apple> Validation data:', content);
+  logDebug(
+    '<Apple> Validation data:',
+    _.mapValues(content, function (value, key) {
+      if (key === 'password') {
+        return '******';
+      }
+      return value;
+    })
+  );
 
   function detectBool(s) {
     if (typeof s === 'boolean') {


### PR DESCRIPTION
Hi @ladeiko.

I noticed that the password is being exposed in the logs (for me, in AWS), and I considered it a security vector. I find the debugging ability in production very useful for diagnosing issues, but I wouldn't want my shared secret to be visible in this scenario.

I thought I'd create a PR straight away, in case you agreed with this approach, in order to speed things up.

Either way, I'm keen to get your thoughts on this.